### PR TITLE
IP -> Static URL

### DIFF
--- a/test.py
+++ b/test.py
@@ -1,7 +1,7 @@
 import crawlingathome as cah
 
 client = cah.init(
-    url="http://34.72.3.121/",
+    url="http://crawlingathome.duckdns.org/",
     nickname= "rvencu"
 )
 


### PR DESCRIPTION
Instead of using an IP address, this helps stop the worker breaking if we eventually switch servers as we can change the server IP/CNAME records through DuckDNS without having to manually edit the source code of all workers.